### PR TITLE
refine formatting for basic page; not tested except in browser dev tool

### DIFF
--- a/html/templates/basic_page.html
+++ b/html/templates/basic_page.html
@@ -28,14 +28,11 @@ A yamz page
   <tr>
     <td>
       {% if headline %}
-      <h3>{{ headline }}</h3>
+      <br/>
+      <h1>{{ headline }}</h3>
       {% endif %}
-
-      <p class="jetstrap-selected" contenteditable="false"
-        style="background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAALHRFWHRDcmVhdGlvbiBUaW1lAEZyaSAxMiBOb3YgMjAxMCAxOTowNzowMiArMTIwMOGr8p4AAAAHdElNRQfaCwwGBxwduq16AAAACXBIWXMAAAsSAAALEgHS3X78AAAABGdBTUEAALGPC/xhBQAAAfJJREFUeNqVkk1vElEUhp87X4CIFhhMG0toMC5K3Lgxbro10bhxY2Jc+CO666Y/oP/DxFVjTKM7l1apTdM0JSU0LSg0WqaUjwE6MDNebGpKBYlndc+55zw5H6/gim2UUd0qs5Uy6VaTa7EYdtOmUN7naHER92q+dtnZ2UFpHTOTXWfuwxrfYlNUHz1lxvdIVyx6MuXHPwFeBLW2z+29Pepr7ziUof7SEq1CibCEmKMAymXH6SD6LrpzRndQPIjNz9P3odu2URlhQ4C+ghcM0JpLEchkzrv7eIDS62JYP2lPBJS2cIMhyrMpwo+fMbW8jLhhc2t3F906pjoK8GcH29vonoenRDk1m5zcvUM6ZuJvZEnmcljT09hbR6iVIuLJw/PxhgAOPOj26Gk1nEQCNWAQ7XS4bxvw8hWuGedeo4iR+/y7+OtfgM1N9OIBwnFQ5SLdZJJ2JML17BdqEuYHgmiahsjnx4zw/i2fslm8dht/YQHx/AWpfI50/ZTKm9d8lykiHkf4/hjA6ipnF++VFRS7T1AoaDejyCEYlHmWNeEKF9YISz30CBkGirxKUIZGamAsQG2hux66BAipi1A6g/5fAM/HkGrUFfmr6wSSiWHJTwQoPrq8hCYEGDoh0xzfwUhyIY9ROkRrNKQ65e1P6uM7+AW+ibcHEM1ixAAAAABJRU5ErkJggg==); background-position: 708px 0px; background-repeat: no-repeat no-repeat;">
-      </p>
     </td>
-    <td valign=top align=right width=30%>
+    <td valign=center align=right width=30%>
       <form action="/search" method="post">
         <div class="control-group"><label class="control-label"></label>
           <div class="controls"><input name="term_string" type="text" class="input-lg search-query form-control"


### PR DESCRIPTION
Tweaking some formatting after the library upgrades. (I've not tested in any live yamz yet.)
I'm trying out eliminating the invisible background image on line 35, which is risky because I don't know what purpose it serves. Looks distinctly kludgey and in the developer tools mode a "Term" page looked much better without it. That same image appears a few other places, so if this works out, maybe it can be removed from them as well?